### PR TITLE
Set same Github BG color

### DIFF
--- a/theme.user.css
+++ b/theme.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
 @name           Buildkite Dark Theme
 @namespace      github.com/one-dark
-@version        3.0.6
+@version        3.0.7
 @description    Relief the stress on your eyes when using Buildkite with this custom dark theme! This theme is inspired by the GitHub dark theme that was recently released.
 @author         Mark Skelton
 @license        ISC

--- a/theme.user.css
+++ b/theme.user.css
@@ -9,7 +9,7 @@
 ==/UserStyle== */
 @-moz-document regexp("https://buildkite\\.com/(?!docs).*") {
   :root {
-    --base-0: hsl(0, 0%, 5%);
+    --base-0: #0d1117;
     --base-1000: hsl(0, 0%, 95%);
     --gray-100: hsl(0, 0%, 8%);
     --gray-200: hsl(0, 0%, 9%);


### PR DESCRIPTION
Avoid little flickering when jumping between github and buildkite by having axactly the same BG color

- [x] I've updated the `@version` at the top of `theme.user.css`.
- [X] I've formatted `theme.user.css` with [Prettier](https://prettier.io).
